### PR TITLE
Simplified Libcast API and cached API calls

### DIFF
--- a/libcast_xblock/public/html/video.html
+++ b/libcast_xblock/public/html/video.html
@@ -11,13 +11,13 @@
       preload="none"
       width="100%"
       height="375px"
-      poster="{{ thumbnail_url }}"
+      poster="{{ resource.thumbnail_url }}"
       data-setup='{ "playbackRates": [0.5, 1, 1.5, 2] }'
       >
-      {% for source in video_sources %}
+      {% for source in resource.video_sources %}
       <source src="{{ source.url }}" type="{{ source.type }}" label="{{ source.label }}" res="{{ source.res }}"/>
       {% endfor %}
-      {% for subtitle in subtitles %}
+      {% for subtitle in resource.subtitles %}
       <track src="{{ transcript_root_url }}?id={{ subtitle.id|urlencode }}" kind="subtitles" srclang="{{ subtitle.language }}" label="{{ subtitle.language_label}}">
       {% endfor %}
       <p class="vjs-no-js">To view this video please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
@@ -26,9 +26,9 @@
     <div class="transcript"></div>
   </div>
 
-  {% if downloadable_files %}
+  {% if resource.downloadable_files %}
   <p>Télécharger la vidéo :
-    {% for file in downloadable_files %}
+    {% for file in resource.downloadable_files %}
     <a href="{{ file.url }}" target="_blank">{{ file.name }}</a>
     {% if not forloop.last %}/{% endif %}
     {% endfor %}


### PR DESCRIPTION
We simplify the way we interact with the libcast library. Also, we
should now hit the libcast resource cache whenever we make libcast
requests.
